### PR TITLE
Traverser la chaine

### DIFF
--- a/node.proto
+++ b/node.proto
@@ -119,6 +119,20 @@ message GetNewTxReply {
   Tx tx = 1;
 }
 
+message GetBlockAfterRequest {
+  bytes hash = 1;
+};
+message GetBlockAfterResponse {
+  bytes next_block_hash = 1;
+}
+
+message GetBlockByHeightRequest {
+  uint32 height = 1;
+}
+message GetBlockByHeightResponse {
+  bytes hash = 1;
+}
+
 service Node {
   rpc GetInfo(GetInfoRequest) returns (GetInfoReply) {}
   rpc PublishRawTx(PublishRawTxRequest) returns (PublishRawTxReply) {}
@@ -131,4 +145,8 @@ service Node {
   rpc DisconnectPeer(DisconnectPeerRequest) returns (DisconnectPeerReply) {}
   rpc GetBestBlocks(GetBestBlocksRequest) returns (stream GetBestBlocksReply) {}
   rpc GetNewTx(GetNewTxRequest) returns (stream GetNewTxReply) {}
+
+  rpc GetBlockAfter(GetBlockAfterRequest) returns (GetBlockAfterResponse) {}
+  rpc GetBlockByHeight(GetBlockByHeightRequest)
+      returns (GetBlockByHeightResponse) {}
 }


### PR DESCRIPTION
Il n'y que moyen de remonter la chaine actuellement. C'est tres desagreable pour la synchronisation puisque on ne peut facilement se resynchroniser apres une sauvegarde de l'etat de la chaine sans devoir gerer les forks alors qu'on est profondement dans la chaine.

Cela permet aussi de partir du premier block et de parcourir la chaine au lieu de devoir le faire dans l'autre sens actuellement